### PR TITLE
standardize workflows for build-resources v4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,21 +1,25 @@
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
+---
 version: 2
 updates:
-  - package-ecosystem: github-actions
+  - package-ecosystem: "github-actions"
     assignees:
-      - kernelsam
+      - "kernelsam"
     cooldown:
       default-days: 21
-    directory: /
+      exclude:
+        - "senzing-factory/*"
+    directory: "/"
+    groups:
+      senzing-factory:
+        patterns:
+          - "senzing-factory/*"
     schedule:
-      interval: daily
-  - package-ecosystem: gomod
+      interval: "daily"
+  - package-ecosystem: "gomod"
     assignees:
-      - docktermj
+      - "docktermj"
     cooldown:
       default-days: 21
-    directory: /
+    directory: "/"
     schedule:
-      interval: daily
+      interval: "daily"

--- a/.github/workflows/add-labels-standardized.yaml
+++ b/.github/workflows/add-labels-standardized.yaml
@@ -14,14 +14,15 @@ jobs:
       issues: write
     secrets:
       ORG_MEMBERSHIP_TOKEN: ${{ secrets.ORG_MEMBERSHIP_TOKEN }}
-      SENZING_MEMBERS: ${{ secrets.SENZING_MEMBERS }}
-    uses: senzing-factory/build-resources/.github/workflows/add-labels-to-issue.yaml@v3
+      MEMBERS: ${{ secrets.SENZING_MEMBERS }}
+    uses: senzing-factory/build-resources/.github/workflows/add-labels-to-issue.yaml@v4
 
   slack-notification:
     needs: [add-issue-labels]
-    if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.add-issue-labels.outputs.job-status) }}
+    if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.add-issue-labels.result) }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v3
+      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v4
     with:
-      job-status: ${{ needs.add-issue-labels.outputs.job-status }}
+      job-status: ${{ needs.add-issue-labels.result }}

--- a/.github/workflows/add-to-project-garage-dependabot.yaml
+++ b/.github/workflows/add-to-project-garage-dependabot.yaml
@@ -11,16 +11,17 @@ jobs:
     permissions:
       repository-projects: write
     secrets:
-      SENZING_GITHUB_PROJECT_RW_TOKEN: ${{ secrets.SENZING_GITHUB_PROJECT_RW_TOKEN }}
-    uses: senzing-factory/build-resources/.github/workflows/add-to-project-dependabot.yaml@v3
+      PROJECT_RW_TOKEN: ${{ secrets.SENZING_GITHUB_PROJECT_RW_TOKEN }}
+    uses: senzing-factory/build-resources/.github/workflows/add-to-project-dependabot.yaml@v4
     with:
       project: ${{ vars.SENZING_PROJECT_GARAGE }}
 
   slack-notification:
     needs: [add-to-project-dependabot]
-    if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.add-to-project-dependabot.outputs.job-status) }}
+    if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.add-to-project-dependabot.result) }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v3
+      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v4
     with:
-      job-status: ${{ needs.add-to-project-dependabot.outputs.job-status }}
+      job-status: ${{ needs.add-to-project-dependabot.result }}

--- a/.github/workflows/add-to-project-garage.yaml
+++ b/.github/workflows/add-to-project-garage.yaml
@@ -13,17 +13,18 @@ jobs:
     permissions:
       repository-projects: write
     secrets:
-      SENZING_GITHUB_PROJECT_RW_TOKEN: ${{ secrets.SENZING_GITHUB_PROJECT_RW_TOKEN }}
-    uses: senzing-factory/build-resources/.github/workflows/add-to-project.yaml@v3
+      PROJECT_RW_TOKEN: ${{ secrets.SENZING_GITHUB_PROJECT_RW_TOKEN }}
+    uses: senzing-factory/build-resources/.github/workflows/add-to-project.yaml@v4
     with:
       project-number: ${{ vars.SENZING_PROJECT_GARAGE }}
       org: ${{ vars.SENZING_GITHUB_ACCOUNT_NAME }}
 
   slack-notification:
     needs: [add-to-project]
-    if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.add-to-project.outputs.job-status) }}
+    if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.add-to-project.result) }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v3
+      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v4
     with:
-      job-status: ${{ needs.add-to-project.outputs.job-status }}
+      job-status: ${{ needs.add-to-project.result }}

--- a/.github/workflows/claude-pr-review.yaml
+++ b/.github/workflows/claude-pr-review.yaml
@@ -12,7 +12,7 @@ permissions: {}
 
 jobs:
   review:
-    uses: senzing-factory/build-resources/.github/workflows/claude-pull-request-review.yaml@v3
+    uses: senzing-factory/build-resources/.github/workflows/claude-pull-request-review.yaml@v4
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/dependabot-approve-and-merge.yaml
+++ b/.github/workflows/dependabot-approve-and-merge.yaml
@@ -16,8 +16,8 @@ jobs:
       contents: write
       pull-requests: write
     secrets:
-      SENZING_GITHUB_CODEOWNER_PR_RW_TOKEN: ${{ secrets.SENZING_GITHUB_CODEOWNER_PR_RW_TOKEN }}
-    uses: senzing-factory/build-resources/.github/workflows/dependabot-approve-and-merge.yaml@v3
+      CODEOWNER_PR_RW_TOKEN: ${{ secrets.SENZING_GITHUB_CODEOWNER_PR_RW_TOKEN }}
+    uses: senzing-factory/build-resources/.github/workflows/dependabot-approve-and-merge.yaml@v4
     with:
       update-type: "minor"
 
@@ -26,7 +26,7 @@ jobs:
       contents: write
       pull-requests: write
     secrets:
-      SENZING_GITHUB_CODEOWNER_PR_RW_TOKEN: ${{ secrets.SENZING_GITHUB_CODEOWNER_PR_RW_TOKEN }}
-    uses: senzing-factory/build-resources/.github/workflows/dependabot-approve-and-merge.yaml@v3
+      CODEOWNER_PR_RW_TOKEN: ${{ secrets.SENZING_GITHUB_CODEOWNER_PR_RW_TOKEN }}
+    uses: senzing-factory/build-resources/.github/workflows/dependabot-approve-and-merge.yaml@v4
     with:
       update-type: "patch"

--- a/.github/workflows/docker-push-containers-to-dockerhub.yaml
+++ b/.github/workflows/docker-push-containers-to-dockerhub.yaml
@@ -40,6 +40,7 @@ jobs:
     if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.docker-push-containers-to-dockerhub.outputs.status) }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v3
+      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v4
     with:
       job-status: ${{ needs.docker-push-containers-to-dockerhub.outputs.status }}

--- a/.github/workflows/docker-verify-refreshed-at-updated.yaml
+++ b/.github/workflows/docker-verify-refreshed-at-updated.yaml
@@ -18,4 +18,4 @@ jobs:
     name: Verify Dockerfiles REFRESHED_AT Updated
     permissions:
       contents: read
-    uses: senzing-factory/build-resources/.github/workflows/verify-dockerfile-refreshed-at-updated.yaml@v3
+    uses: senzing-factory/build-resources/.github/workflows/verify-dockerfile-refreshed-at-updated.yaml@v4

--- a/.github/workflows/go-proxy-pull.yaml
+++ b/.github/workflows/go-proxy-pull.yaml
@@ -27,6 +27,7 @@ jobs:
     if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.go-proxy-pull.outputs.status) }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v3
+      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v4
     with:
       job-status: ${{ needs.go-proxy-pull.outputs.status }}

--- a/.github/workflows/go-test-darwin.yaml
+++ b/.github/workflows/go-test-darwin.yaml
@@ -91,7 +91,7 @@ jobs:
     needs: go-test-darwin
     permissions:
       contents: read
-    uses: senzing-factory/build-resources/.github/workflows/go-coverage.yaml@v3
+    uses: senzing-factory/build-resources/.github/workflows/go-coverage.yaml@v4
     with:
       coverage-config: ./.github/coverage/testcoverage.yaml
       profile: "cover-production-v4.out,cover-staging-v4.out"
@@ -101,6 +101,7 @@ jobs:
     if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.go-test-darwin.result ) && github.event_name == 'schedule' }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v3
+      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v4
     with:
       job-status: ${{ needs.go-test-darwin.result }}

--- a/.github/workflows/go-test-linux-tls-mutual.yaml
+++ b/.github/workflows/go-test-linux-tls-mutual.yaml
@@ -105,6 +105,7 @@ jobs:
     if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.go-test-linux.result ) && (github.ref_name == github.event.repository.default_branch || github.event_name == 'schedule') }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v3
+      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v4
     with:
       job-status: ${{ needs.go-test-linux.result }}

--- a/.github/workflows/go-test-linux-tls-not-used.yaml
+++ b/.github/workflows/go-test-linux-tls-not-used.yaml
@@ -73,6 +73,7 @@ jobs:
     if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.go-test-linux.result ) && (github.ref_name == github.event.repository.default_branch || github.event_name == 'schedule') }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v3
+      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v4
     with:
       job-status: ${{ needs.go-test-linux.result }}

--- a/.github/workflows/go-test-linux-tls-server-side.yaml
+++ b/.github/workflows/go-test-linux-tls-server-side.yaml
@@ -99,6 +99,7 @@ jobs:
     if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.go-test-linux.result ) && (github.ref_name == github.event.repository.default_branch || github.event_name == 'schedule') }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v3
+      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v4
     with:
       job-status: ${{ needs.go-test-linux.result }}

--- a/.github/workflows/go-test-linux.yaml
+++ b/.github/workflows/go-test-linux.yaml
@@ -90,7 +90,7 @@ jobs:
     needs: go-test-linux
     permissions:
       contents: read
-    uses: senzing-factory/build-resources/.github/workflows/go-coverage.yaml@v3
+    uses: senzing-factory/build-resources/.github/workflows/go-coverage.yaml@v4
     with:
       coverage-config: ./.github/coverage/testcoverage.yaml
       profile: "cover-production-v4.out,cover-staging-v4.out"
@@ -100,6 +100,7 @@ jobs:
     if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.go-test-linux.result ) && (github.ref_name == github.event.repository.default_branch || github.event_name == 'schedule') }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v3
+      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v4
     with:
       job-status: ${{ needs.go-test-linux.result }}

--- a/.github/workflows/go-test-windows.yaml
+++ b/.github/workflows/go-test-windows.yaml
@@ -87,7 +87,7 @@ jobs:
     needs: go-test-windows
     permissions:
       contents: read
-    uses: senzing-factory/build-resources/.github/workflows/go-coverage.yaml@v3
+    uses: senzing-factory/build-resources/.github/workflows/go-coverage.yaml@v4
     with:
       coverage-config: ./.github/coverage/testcoverage.yaml
       profile: "cover-production-v4.out,cover-staging-v4.out"
@@ -97,6 +97,7 @@ jobs:
     if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.go-test-windows.result ) && github.event_name == 'schedule' }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v3
+      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v4
     with:
       job-status: ${{ needs.go-test-windows.result }}

--- a/.github/workflows/link-issues-to-pr-post-merge.yaml
+++ b/.github/workflows/link-issues-to-pr-post-merge.yaml
@@ -13,4 +13,4 @@ jobs:
     permissions:
       pull-requests: write
       contents: read
-    uses: senzing-factory/build-resources/.github/workflows/link-issues-to-pull-request-post-merge.yaml@v3
+    uses: senzing-factory/build-resources/.github/workflows/link-issues-to-pull-request-post-merge.yaml@v4

--- a/.github/workflows/lint-workflows.yaml
+++ b/.github/workflows/lint-workflows.yaml
@@ -15,6 +15,6 @@ jobs:
     permissions:
       contents: read
       packages: read
-      pull-requests: read
+      pull-requests: write
       statuses: write
-    uses: senzing-factory/build-resources/.github/workflows/lint-workflows.yaml@v3
+    uses: senzing-factory/build-resources/.github/workflows/lint-workflows.yaml@v4

--- a/.github/workflows/make-go-github-file.yaml
+++ b/.github/workflows/make-go-github-file.yaml
@@ -13,16 +13,17 @@ jobs:
       contents: write
       pull-requests: write
     secrets:
-      SENZING_GITHUB_ACTOR: ${{ secrets.SENZING_GITHUB_ACTOR }}
-      SENZING_GITHUB_GPG_PASSPHRASE: ${{ secrets.SENZING_GITHUB_GPG_PASSPHRASE }}
-      SENZING_GITHUB_GPG_PRIVATE_KEY: ${{ secrets.SENZING_GITHUB_GPG_PRIVATE_KEY }}
-    uses: senzing-factory/build-resources/.github/workflows/make-go-github-file.yaml@v3
+      GIT_ACTOR: ${{ secrets.SENZING_GITHUB_ACTOR }}
+      GPG_PASSPHRASE: ${{ secrets.SENZING_GITHUB_GPG_PASSPHRASE }}
+      GPG_PRIVATE_KEY: ${{ secrets.SENZING_GITHUB_GPG_PRIVATE_KEY }}
+    uses: senzing-factory/build-resources/.github/workflows/make-go-github-file.yaml@v4
 
   slack-notification:
     needs: [make-go-github-file]
-    if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.make-go-github-file.outputs.job-status) }}
+    if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.make-go-github-file.result) }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v3
+      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v4
     with:
-      job-status: ${{ needs.make-go-github-file.outputs.job-status }}
+      job-status: ${{ needs.make-go-github-file.result }}

--- a/.github/workflows/make-go-tag.yaml
+++ b/.github/workflows/make-go-tag.yaml
@@ -36,6 +36,7 @@ jobs:
     if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.make-go-tag.outputs.status ) }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v3
+      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v4
     with:
       job-status: ${{ needs.make-go-tag.outputs.status }}

--- a/.github/workflows/move-pr-to-done-dependabot.yaml
+++ b/.github/workflows/move-pr-to-done-dependabot.yaml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       repository-projects: write
     secrets:
-      SENZING_GITHUB_PROJECT_RW_TOKEN: ${{ secrets.SENZING_GITHUB_PROJECT_RW_TOKEN }}
-    uses: senzing-factory/build-resources/.github/workflows/move-pr-to-done-dependabot.yaml@v3
+      PROJECT_RW_TOKEN: ${{ secrets.SENZING_GITHUB_PROJECT_RW_TOKEN }}
+    uses: senzing-factory/build-resources/.github/workflows/move-pr-to-done-dependabot.yaml@v4
     with:
       project: ${{ vars.SENZING_PROJECT_GARAGE }}

--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -14,4 +14,4 @@ jobs:
   spellcheck:
     permissions:
       contents: read
-    uses: senzing-factory/build-resources/.github/workflows/cspell.yaml@v3
+    uses: senzing-factory/build-resources/.github/workflows/cspell.yaml@v4


### PR DESCRIPTION
## Summary

- Rename reusable workflow secret keys for build-resources v4
- Replace `.outputs.job-status` with `.result`
- Add `SLACK_CHANNEL` secret to slack notification callers
- Bump all build-resources workflow refs to `@v4`
- Standardize dependabot config (cooldown, groups, assignees)
- Add `kernelsam` and `cooldown` to cspell dictionary